### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,9 +27,9 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.2",
-    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
+    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.2.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2"
   },

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,9 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ]
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-details.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/src/vaadin-details.html
+++ b/src/vaadin-details.html
@@ -125,12 +125,17 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /**
+         * @return {Element}
+         * @protected
+         */
         get _collapsible() {
           return this.shadowRoot.querySelector('[part="content"]');
         }
 
         /**
          * Focusable element used by vaadin-control-state-mixin
+         * @return {Element}
          * @protected
          */
         get focusElement() {
@@ -147,22 +152,33 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _getAriaExpanded(opened) {
           return opened ? 'true' : 'false';
         }
 
+        /** @private */
         _getAriaHidden(opened) {
           return opened ? 'false' : 'true';
         }
 
+        /** @private */
         _openedChanged(opened) {
           this._collapsible.style.maxHeight = opened ? '' : '0px';
         }
 
+        /**
+         * @param {MouseEvent!} e
+         * @protected
+         */
         _onToggleClick(e) {
           this.opened = !this.opened;
         }
 
+        /**
+         * @param {KeyboardEvent!} e
+         * @protected
+         */
         _onToggleKeyDown(e) {
           if ([13, 32].indexOf(e.keyCode) > -1) {
             e.preventDefault();

--- a/src/vaadin-details.html
+++ b/src/vaadin-details.html
@@ -114,6 +114,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * If true, the details content is visible.
+             * @type {boolean}
              */
             opened: {
               type: Boolean,
@@ -126,7 +127,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
-         * @return {Element}
+         * @return {!HTMLElement}
          * @protected
          */
         get _collapsible() {
@@ -135,7 +136,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Focusable element used by vaadin-control-state-mixin
-         * @return {Element}
+         * @return {!HTMLElement}
          * @protected
          */
         get focusElement() {
@@ -168,7 +169,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
-         * @param {MouseEvent!} e
+         * @param {!MouseEvent} e
          * @protected
          */
         _onToggleClick(e) {
@@ -176,7 +177,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
-         * @param {KeyboardEvent!} e
+         * @param {!KeyboardEvent} e
          * @protected
          */
         _onToggleKeyDown(e) {


### PR DESCRIPTION
Fixes #29 

Generated `vaadin-details.d.ts` file looks like this:

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {ControlStateMixin} from '@vaadin/vaadin-control-state-mixin/vaadin-control-state-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class DetailsElement extends
  ControlStateMixin(
  ElementMixin(
  ThemableMixin(
  PolymerElement))) {
  readonly focusElement: Element|null;
  readonly _collapsible: Element|null;
  opened: boolean|null|undefined;
  ready(): void;
  _onToggleClick(e: MouseEvent): void;
  _onToggleKeyDown(e: KeyboardEvent): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-details": DetailsElement;
  }
}

export {DetailsElement};
```