### PR TITLE
fix: do not delegate focus when clicking on non-focusable child

### DIFF
--- a/package-lock-p3.json
+++ b/package-lock-p3.json
@@ -1812,9 +1812,9 @@
       "optional": true
     },
     "node_modules/@vaadin/vaadin-control-state-mixin": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.4.tgz",
-      "integrity": "sha512-oGsNaWbM6RisY1LkyWYtwnw+DtSRSpkFDbemEOtkYezj+Hhsd9+07LqILaUU4pB0zPaRq+uq+2tKba/TL3t23g==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.5.tgz",
+      "integrity": "sha512-Vd1LcJTdS2VHut/FqrvrJNij9RuhHhLY+Cc6sVYKjl3suPmypeQ77J6DroDTmqLDHebCBQWaRMzGqnBDS1SSVA==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -14681,9 +14681,9 @@
       "optional": true
     },
     "@vaadin/vaadin-control-state-mixin": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.4.tgz",
-      "integrity": "sha512-oGsNaWbM6RisY1LkyWYtwnw+DtSRSpkFDbemEOtkYezj+Hhsd9+07LqILaUU4pB0zPaRq+uq+2tKba/TL3t23g==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.5.tgz",
+      "integrity": "sha512-Vd1LcJTdS2VHut/FqrvrJNij9RuhHhLY+Cc6sVYKjl3suPmypeQ77J6DroDTmqLDHebCBQWaRMzGqnBDS1SSVA==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }

--- a/package-lock-p3.json
+++ b/package-lock-p3.json
@@ -1812,9 +1812,9 @@
       "optional": true
     },
     "node_modules/@vaadin/vaadin-control-state-mixin": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.5.tgz",
-      "integrity": "sha512-Vd1LcJTdS2VHut/FqrvrJNij9RuhHhLY+Cc6sVYKjl3suPmypeQ77J6DroDTmqLDHebCBQWaRMzGqnBDS1SSVA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.6.tgz",
+      "integrity": "sha512-3edQSooBoHVC3RexL6hi3/26HMGvG1jlxLq6ffH9c+GapuZ9zh6E2KyZa/Sz1jmLZwfZII7exgwkHhEYUZZrJA==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -14681,9 +14681,9 @@
       "optional": true
     },
     "@vaadin/vaadin-control-state-mixin": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.5.tgz",
-      "integrity": "sha512-Vd1LcJTdS2VHut/FqrvrJNij9RuhHhLY+Cc6sVYKjl3suPmypeQ77J6DroDTmqLDHebCBQWaRMzGqnBDS1SSVA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.6.tgz",
+      "integrity": "sha512-3edQSooBoHVC3RexL6hi3/26HMGvG1jlxLq6ffH9c+GapuZ9zh6E2KyZa/Sz1jmLZwfZII7exgwkHhEYUZZrJA==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }

--- a/src/vaadin-details.html
+++ b/src/vaadin-details.html
@@ -143,6 +143,24 @@ This program is available under Apache License Version 2.0, available at https:/
           return this.shadowRoot.querySelector('[part="summary"]');
         }
 
+        /**
+         * Override logic from vaadin-control-state-mixin to only focus the summary element
+         * when using keyboard navigation. This avoids issues when clicking into the details,
+         * such as text selection and click events not working
+         * @override
+         * @protected
+         */
+        _focus() {
+          if (!this.focusElement || this._isShiftTabbing) {
+            return;
+          }
+
+          if (this._keyboardActive) {
+            this.focusElement.focus();
+          }
+          this._setFocused(true);
+        }
+
         ready() {
           super.ready();
           // prevent Shift + Tab on content from host blur

--- a/test/details.html
+++ b/test/details.html
@@ -131,6 +131,8 @@
         beforeEach(() => {
           details = fixture('default');
           input = details.querySelector('input');
+          // Force reset of global keyboardActive state in ControlStateMixin between tests
+          MockInteractions.down(document.body);
         });
 
         it('should stop Shift + Tab on the content from propagating to the host', () => {
@@ -138,6 +140,31 @@
           details.addEventListener('keydown', spy);
           MockInteractions.keyDownOn(input, 9, 'shift', 'Tab');
           expect(spy).to.not.be.called;
+        });
+
+        it('should delegate focus to summary element when using keyboard navigation', () => {
+          const spy = sinon.spy(details.focusElement, 'focus');
+          // Simulate focus in into details, while pressing tab key
+          MockInteractions.keyDownOn(document.body, 9, null, 'Tab');
+          const event = new CustomEvent('focusin', {bubbles: true, composed: true});
+          event.relatedTarget = document.body;
+          details.dispatchEvent(event);
+
+          expect(spy).to.be.called;
+          // Should set focused attribute in any case
+          expect(details.hasAttribute('focused')).to.be.true;
+        });
+
+        it('should not delegate focus to summary element when not using keyboard navigation', () => {
+          const spy = sinon.spy(details.focusElement, 'focus');
+          // Simulate focus in into details, without pressing key
+          const event = new CustomEvent('focusin', {bubbles: true, composed: true});
+          event.relatedTarget = document.body;
+          details.dispatchEvent(event);
+
+          expect(spy).to.not.be.called;
+          // Should set focused attribute in any case
+          expect(details.hasAttribute('focused')).to.be.true;
         });
       });
     });

--- a/test/details.html
+++ b/test/details.html
@@ -166,6 +166,19 @@
           // Should set focused attribute in any case
           expect(details.hasAttribute('focused')).to.be.true;
         });
+
+        it('should not delegate focus when shift-tabbing', () => {
+          const spy = sinon.spy(details.focusElement, 'focus');
+          // Simulate focus in into details, while Shift-Tabbing
+          MockInteractions.keyDownOn(details, 9, 'shift', 'Tab');
+          const event = new CustomEvent('focusin', {bubbles: true, composed: true});
+          event.relatedTarget = document.body;
+          details.dispatchEvent(event);
+
+          expect(spy).to.not.be.called;
+          // Should not set focused attribute
+          expect(details.hasAttribute('focused')).to.be.false;
+        });
       });
     });
   </script>


### PR DESCRIPTION
Back-port of https://github.com/vaadin/web-components/pull/3565